### PR TITLE
Make Element implement WrapsDriver interface

### DIFF
--- a/CLA-individual.txt
+++ b/CLA-individual.txt
@@ -97,3 +97,4 @@ The following have accepted and agreed to these terms and conditions,
 as evidenced by their digital signatures and information below.
 
 [Full Name] [GitHub profile URL] [YYYY-MM-DD]
+Philipp Katz, https://github.com/qqilihq, 2016-02-10

--- a/src/com/machinepublishers/jbrowserdriver/Element.java
+++ b/src/com/machinepublishers/jbrowserdriver/Element.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.OutputType;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.internal.Coordinates;
@@ -37,48 +38,52 @@ import org.openqa.selenium.internal.FindsByName;
 import org.openqa.selenium.internal.FindsByTagName;
 import org.openqa.selenium.internal.FindsByXPath;
 import org.openqa.selenium.internal.Locatable;
+import org.openqa.selenium.internal.WrapsDriver;
 
 class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClassName,
-    FindsByLinkText, FindsByName, FindsByCssSelector, FindsByTagName, FindsByXPath, Locatable {
+    FindsByLinkText, FindsByName, FindsByCssSelector, FindsByTagName, FindsByXPath, Locatable, 
+    WrapsDriver {
   private final ElementRemote remote;
   private final Logs logs;
+  private final JBrowserDriver driver;
 
-  private Element(ElementRemote remote, Logs logs) {
+  private Element(ElementRemote remote, JBrowserDriver driver, Logs logs) {
     this.remote = remote;
     this.logs = logs;
+    this.driver = driver;
   }
 
-  static List<WebElement> constructList(List<ElementRemote> elements, Logs logs) {
+  static List<WebElement> constructList(List<ElementRemote> elements, JBrowserDriver driver, Logs logs) {
     List<WebElement> ret = new ArrayList<WebElement>();
     if (elements != null) {
       for (ElementRemote element : elements) {
         if (element != null) {
-          ret.add(new Element(element, logs));
+          ret.add(new Element(element, driver, logs));
         }
       }
     }
     return ret;
   }
 
-  static WebElement constructElement(ElementRemote element, Logs logs) {
+  static WebElement constructElement(ElementRemote element, JBrowserDriver driver, Logs logs) {
     if (element == null) {
       return null;
     }
-    return new Element(element, logs);
+    return new Element(element, driver, logs);
   }
 
-  static Object constructObject(Object obj, Logs logs) {
+  static Object constructObject(Object obj, JBrowserDriver driver, Logs logs) {
     if (obj == null) {
       return null;
     }
     if (obj instanceof ElementRemote) {
-      return new Element((ElementRemote) obj, logs);
+      return new Element((ElementRemote) obj, driver, logs);
     }
     if (obj instanceof List<?>) {
       List retList = new ArrayList();
       for (Object item : (List) obj) {
         if (item instanceof ElementRemote) {
-          retList.add(new Element((ElementRemote) item, logs));
+          retList.add(new Element((ElementRemote) item, driver, logs));
         } else {
           retList.add(item);
         }
@@ -259,7 +264,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public WebElement findElement(By by) {
     try {
-      return constructElement(remote.findElement(by), logs);
+      return constructElement(remote.findElement(by), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -272,7 +277,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public List<WebElement> findElements(By by) {
     try {
-      return constructList(remote.findElements(by), logs);
+      return constructList(remote.findElements(by), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -285,7 +290,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public WebElement findElementByXPath(final String expr) {
     try {
-      return constructElement(remote.findElementByXPath(expr), logs);
+      return constructElement(remote.findElementByXPath(expr), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -298,7 +303,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public List<WebElement> findElementsByXPath(final String expr) {
     try {
-      return constructList(remote.findElementsByXPath(expr), logs);
+      return constructList(remote.findElementsByXPath(expr), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -311,7 +316,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public WebElement findElementByTagName(String tagName) {
     try {
-      return constructElement(remote.findElementByTagName(tagName), logs);
+      return constructElement(remote.findElementByTagName(tagName), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -324,7 +329,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public List<WebElement> findElementsByTagName(String tagName) {
     try {
-      return constructList(remote.findElementsByTagName(tagName), logs);
+      return constructList(remote.findElementsByTagName(tagName), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -337,7 +342,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public WebElement findElementByCssSelector(final String expr) {
     try {
-      return constructElement(remote.findElementByCssSelector(expr), logs);
+      return constructElement(remote.findElementByCssSelector(expr), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -350,7 +355,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public List<WebElement> findElementsByCssSelector(final String expr) {
     try {
-      return constructList(remote.findElementsByCssSelector(expr), logs);
+      return constructList(remote.findElementsByCssSelector(expr), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -363,7 +368,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public WebElement findElementByName(String name) {
     try {
-      return constructElement(remote.findElementByName(name), logs);
+      return constructElement(remote.findElementByName(name), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -376,7 +381,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public List<WebElement> findElementsByName(String name) {
     try {
-      return constructList(remote.findElementsByName(name), logs);
+      return constructList(remote.findElementsByName(name), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -389,7 +394,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public WebElement findElementByLinkText(final String text) {
     try {
-      return constructElement(remote.findElementByLinkText(text), logs);
+      return constructElement(remote.findElementByLinkText(text), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -402,7 +407,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public WebElement findElementByPartialLinkText(String text) {
     try {
-      return constructElement(remote.findElementByPartialLinkText(text), logs);
+      return constructElement(remote.findElementByPartialLinkText(text), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -415,7 +420,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public List<WebElement> findElementsByLinkText(String text) {
     try {
-      return constructList(remote.findElementsByLinkText(text), logs);
+      return constructList(remote.findElementsByLinkText(text), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -428,7 +433,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public List<WebElement> findElementsByPartialLinkText(String text) {
     try {
-      return constructList(remote.findElementsByPartialLinkText(text), logs);
+      return constructList(remote.findElementsByPartialLinkText(text), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -441,7 +446,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public WebElement findElementByClassName(String cssClass) {
     try {
-      return constructElement(remote.findElementByClassName(cssClass), logs);
+      return constructElement(remote.findElementByClassName(cssClass), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -454,7 +459,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public List<WebElement> findElementsByClassName(String cssClass) {
     try {
-      return constructList(remote.findElementsByClassName(cssClass), logs);
+      return constructList(remote.findElementsByClassName(cssClass), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -467,7 +472,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public WebElement findElementById(final String id) {
     try {
-      return constructElement(remote.findElementById(id), logs);
+      return constructElement(remote.findElementById(id), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -480,7 +485,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public List<WebElement> findElementsById(String id) {
     try {
-      return constructList(remote.findElementsById(id), logs);
+      return constructList(remote.findElementsById(id), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -493,7 +498,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public Object executeAsyncScript(final String script, final Object... args) {
     try {
-      return constructObject(remote.executeAsyncScript(script, args), logs);
+      return constructObject(remote.executeAsyncScript(script, args), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -506,7 +511,7 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
   @Override
   public Object executeScript(final String script, final Object... args) {
     try {
-      return constructObject(remote.executeScript(script, args), logs);
+      return constructObject(remote.executeScript(script, args), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -546,4 +551,10 @@ class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClass
       return null;
     }
   }
+
+  @Override
+  public WebDriver getWrappedDriver() {
+	return driver;
+  }
+
 }

--- a/src/com/machinepublishers/jbrowserdriver/JBrowserDriver.java
+++ b/src/com/machinepublishers/jbrowserdriver/JBrowserDriver.java
@@ -434,7 +434,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public WebElement findElement(By by) {
     try {
-      return Element.constructElement(remote.findElement(by), logs);
+      return Element.constructElement(remote.findElement(by), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -447,7 +447,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public List<WebElement> findElements(By by) {
     try {
-      return Element.constructList(remote.findElements(by), logs);
+      return Element.constructList(remote.findElements(by), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -460,7 +460,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public WebElement findElementById(String id) {
     try {
-      return Element.constructElement(remote.findElementById(id), logs);
+      return Element.constructElement(remote.findElementById(id), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -473,7 +473,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public List<WebElement> findElementsById(String id) {
     try {
-      return Element.constructList(remote.findElementsById(id), logs);
+      return Element.constructList(remote.findElementsById(id), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -486,7 +486,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public WebElement findElementByXPath(String expr) {
     try {
-      return Element.constructElement(remote.findElementByXPath(expr), logs);
+      return Element.constructElement(remote.findElementByXPath(expr), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -499,7 +499,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public List<WebElement> findElementsByXPath(String expr) {
     try {
-      return Element.constructList(remote.findElementsByXPath(expr), logs);
+      return Element.constructList(remote.findElementsByXPath(expr), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -512,7 +512,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public WebElement findElementByLinkText(final String text) {
     try {
-      return Element.constructElement(remote.findElementByLinkText(text), logs);
+      return Element.constructElement(remote.findElementByLinkText(text), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -525,7 +525,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public WebElement findElementByPartialLinkText(String text) {
     try {
-      return Element.constructElement(remote.findElementByPartialLinkText(text), logs);
+      return Element.constructElement(remote.findElementByPartialLinkText(text), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -538,7 +538,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public List<WebElement> findElementsByLinkText(String text) {
     try {
-      return Element.constructList(remote.findElementsByLinkText(text), logs);
+      return Element.constructList(remote.findElementsByLinkText(text), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -551,7 +551,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public List<WebElement> findElementsByPartialLinkText(String text) {
     try {
-      return Element.constructList(remote.findElementsByPartialLinkText(text), logs);
+      return Element.constructList(remote.findElementsByPartialLinkText(text), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -564,7 +564,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public WebElement findElementByClassName(String cssClass) {
     try {
-      return Element.constructElement(remote.findElementByClassName(cssClass), logs);
+      return Element.constructElement(remote.findElementByClassName(cssClass), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -577,7 +577,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public List<WebElement> findElementsByClassName(String cssClass) {
     try {
-      return Element.constructList(remote.findElementsByClassName(cssClass), logs);
+      return Element.constructList(remote.findElementsByClassName(cssClass), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -590,7 +590,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public WebElement findElementByName(String name) {
     try {
-      return Element.constructElement(remote.findElementByName(name), logs);
+      return Element.constructElement(remote.findElementByName(name), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -603,7 +603,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public List<WebElement> findElementsByName(String name) {
     try {
-      return Element.constructList(remote.findElementsByName(name), logs);
+      return Element.constructList(remote.findElementsByName(name), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -616,7 +616,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public WebElement findElementByCssSelector(String expr) {
     try {
-      return Element.constructElement(remote.findElementByCssSelector(expr), logs);
+      return Element.constructElement(remote.findElementByCssSelector(expr), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -629,7 +629,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public List<WebElement> findElementsByCssSelector(String expr) {
     try {
-      return Element.constructList(remote.findElementsByCssSelector(expr), logs);
+      return Element.constructList(remote.findElementsByCssSelector(expr), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -642,7 +642,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public WebElement findElementByTagName(String tagName) {
     try {
-      return Element.constructElement(remote.findElementByTagName(tagName), logs);
+      return Element.constructElement(remote.findElementByTagName(tagName), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -655,7 +655,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public List<WebElement> findElementsByTagName(String tagName) {
     try {
-      return Element.constructList(remote.findElementsByTagName(tagName), logs);
+      return Element.constructList(remote.findElementsByTagName(tagName), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return new ArrayList<WebElement>();
@@ -668,7 +668,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public Object executeAsyncScript(String script, Object... args) {
     try {
-      return Element.constructObject(remote.executeAsyncScript(script, args), logs);
+      return Element.constructObject(remote.executeAsyncScript(script, args), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;
@@ -681,7 +681,7 @@ public class JBrowserDriver implements WebDriver, JavascriptExecutor, FindsById,
   @Override
   public Object executeScript(String script, Object... args) {
     try {
-      return Element.constructObject(remote.executeScript(script, args), logs);
+      return Element.constructObject(remote.executeScript(script, args), this, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;

--- a/src/com/machinepublishers/jbrowserdriver/TargetLocator.java
+++ b/src/com/machinepublishers/jbrowserdriver/TargetLocator.java
@@ -41,7 +41,7 @@ class TargetLocator implements org.openqa.selenium.WebDriver.TargetLocator {
   @Override
   public WebElement activeElement() {
     try {
-      return Element.constructElement(remote.activeElement(), logs);
+      return Element.constructElement(remote.activeElement(), driver, logs);
     } catch (RemoteException e) {
       logs.exception(e);
       return null;


### PR DESCRIPTION
Hi there,

great job with jBrowser driver! I've been recently working on an integration into the [Selenium Nodes](http://seleniumnodes.com) for KNIME, which allow a graphical authoring of Selenium workflows. There, I've been facing one issue:

In the existing environment, we sometimes rely on the fact, that `WebElement`s also implement `WrapsDriver` (this is the case for all elements when working with the "official" Selenium Web Drivers). However, this was not the case for `com.machinepublishers.jbrowserdriver.Element`, that's the reason for this PR.

Best regards,
Philipp