### PR TITLE
Remove compile dependency on slf4j-simple

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,14 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>1.7.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>


### PR DESCRIPTION
Thank you for contributing to this project!

If you haven't already done so, please agree to the Contributor's License Agreement: https://github.com/MachinePublishers/jBrowserDriver/blob/master/CLA-individual.txt

You can edit that file to add your digital signature to the bottom.
Slf4j barfs if more than 1 binding is on classpath.
Bindings are only even needed for an application that is running (or tests).

The fix here is to include the slf4j-api as a compile dependency and move the slf4j-simple to the test scope.