### PR TITLE
send non-default ports with the host header

### DIFF
--- a/CLA-individual.txt
+++ b/CLA-individual.txt
@@ -102,3 +102,4 @@ Travis Rodman, https://github.com/travis-rodman, 2016-02-28
 Joakim Särehag, https://github.com/sarehag, 2016-03-08
 Florian Geyer, https://github.com/BlueIce, 2016-03-10
 Farid Zakaria, https://github.com/fzakaria, 2016-04-17
+Jason Miller, https://github.com/heinousjay, 2016-03-19

--- a/src/com/machinepublishers/jbrowserdriver/StreamConnection.java
+++ b/src/com/machinepublishers/jbrowserdriver/StreamConnection.java
@@ -209,7 +209,14 @@ class StreamConnection extends HttpURLConnection implements Closeable {
     this.urlString = url.toExternalForm();
   }
 
-  private void processHeaders(Settings settings, HttpRequestBase req, String host) {
+  private String hostHeader() {
+    int port = url.getPort();
+    return (port == -1 || port == url.getDefaultPort()) ?
+      url.getHost() :
+      url.getHost() + ":" + port;
+  }
+
+  private void processHeaders(Settings settings, HttpRequestBase req) {
     boolean https = urlString.toLowerCase().startsWith("https://");
     Collection<String> names = settings.headers().headerNames(https);
     for (String name : names) {
@@ -223,7 +230,7 @@ class StreamConnection extends HttpURLConnection implements Closeable {
         if (name.equals("user-agent") && valuesIn != null && !valuesIn.isEmpty()) {
           req.addHeader(nameProperCase, settings.userAgentString());
         } else if (name.equals("host")) {
-          req.addHeader(nameProperCase, host);
+          req.addHeader(nameProperCase, hostHeader());
         } else if (valuesIn != null && !valuesIn.isEmpty()) {
           for (String curVal : valuesIn) {
             req.addHeader(nameProperCase, curVal);
@@ -295,7 +302,7 @@ class StreamConnection extends HttpURLConnection implements Closeable {
           } else if ("TRACE".equals(method.get())) {
             req.set(new HttpTrace(uri));
           }
-          processHeaders(SettingsManager.settings(), req.get(), url.getHost());
+          processHeaders(SettingsManager.settings(), req.get());
           ProxyConfig proxy = SettingsManager.settings().proxy();
           if (proxy != null && !proxy.directConnection()) {
             config.get().setExpectContinueEnabled(proxy.expectContinue());


### PR DESCRIPTION
per https://tools.ietf.org/html/rfc7230#section-5.4 the host
header must include the port, unless the port is the protocol
default.

As there seem to be no automated tests in this repository, I'm not sure what to do for verification. I used the updated snapshot in the project where I discovered this bug, and it now works against defaults and non-default ports, but that's as far as I've gone here