### PR TITLE
Null Pointer Exception when finding elements by link text

### DIFF
--- a/src/com/machinepublishers/jbrowserdriver/ElementServer.java
+++ b/src/com/machinepublishers/jbrowserdriver/ElementServer.java
@@ -759,8 +759,12 @@ class ElementServer extends RemoteObject implements ElementRemote, WebElement,
             List<ElementServer> elements = new ArrayList<ElementServer>();
             List<ElementServer> nodes = (List<ElementServer>) findElementsByTagName("a");
             for (ElementServer cur : nodes) {
-              if ((partial && cur.getText().contains(text))
-                  || (!partial && cur.getText().equals(text))) {
+              String curText = cur.getText();
+              if (curText == null) {
+                continue;
+              }
+              if ((partial && curText.contains(text))
+                  || (!partial && curText.equals(text))) {
                 elements.add(cur);
                 if (!multiple) {
                   break;

--- a/src/com/machinepublishers/jbrowserdriver/diagnostics/test.htm
+++ b/src/com/machinepublishers/jbrowserdriver/diagnostics/test.htm
@@ -15,6 +15,7 @@
     <a href="1" id="anchor1">anchor</a>
     <a href="2" id="anchor2">anchor</a>
     <a href="/" id="anchor3">anchor</a>
+    <a id="anchor4"></a>
     <button onclick="javascript:alert('test-alert');confirm('test-confirm');document.getElementById('testspan').innerHTML=prompt('test-prompt');">test button</button>
     <span id="testspan"></span>
     <input type="text" id="text-input">


### PR DESCRIPTION
This pull request fixes a Null Pointer Exception when finding elements by link text.

The exception appears if the page contains a link element with no text (the `getText()` method returns null). I extended the test.htm with such a case.
