### PR TITLE
Fix logging of exception via LogsServer.

### DIFF
--- a/src/com/machinepublishers/jbrowserdriver/LogsServer.java
+++ b/src/com/machinepublishers/jbrowserdriver/LogsServer.java
@@ -182,6 +182,7 @@ class LogsServer extends RemoteObject implements LogsRemote, org.openqa.selenium
     try {
       writer = new StringWriter();
       throwable.printStackTrace(new PrintWriter(writer));
+      message = writer.toString();
     } catch (Throwable t) {
       message = "While logging a message, an error occurred: " + t.getMessage();
     } finally {


### PR DESCRIPTION
When logging an exception via the method `exception(Throwable throwable)` in `LogsServer` the stacktrace of the exception is written in a StringWriter but not actually used for the resulting message.