### PR TITLE
Fix WebElement#isSelected for not selected/checked input elements.

### DIFF
--- a/src/com/machinepublishers/jbrowserdriver/ElementServer.java
+++ b/src/com/machinepublishers/jbrowserdriver/ElementServer.java
@@ -575,8 +575,8 @@ class ElementServer extends RemoteObject implements ElementRemote, WebElement,
             validate(false);
             String selected = node.getMember("selected").toString();
             String checked = node.getMember("checked").toString();
-            return (selected != null && !"undefined".equals(selected) && !selected.isEmpty())
-                || (checked != null && !"undefined".equals(checked) && !checked.isEmpty());
+            return (selected != null && !"undefined".equals(selected) && !"false".equals(selected) && !selected.isEmpty())
+                || (checked != null && !"undefined".equals(checked) && !"false".equals(checked) && !checked.isEmpty());
           }
         });
   }

--- a/src/com/machinepublishers/jbrowserdriver/diagnostics/Test.java
+++ b/src/com/machinepublishers/jbrowserdriver/diagnostics/Test.java
@@ -291,6 +291,12 @@ public class Test {
       test("Testing\ntext.".equals(driver.findElement(By.id("text-node1")).getText()));
       test("".equals(driver.findElement(By.id("text-node2")).getText()));
       test("".equals(driver.findElement(By.id("text-node3")).getText()));
+      List<WebElement> options = driver.findElementsByCssSelector("#testselect option");
+      test(options.size() == 2);
+      test(options.get(0).isSelected());
+      test(!options.get(1).isSelected());
+      test(driver.findElementById("checkbox1").isSelected());
+      test(!driver.findElementById("checkbox2").isSelected());
 
       /*
        * Cookie manager

--- a/src/com/machinepublishers/jbrowserdriver/diagnostics/test.htm
+++ b/src/com/machinepublishers/jbrowserdriver/diagnostics/test.htm
@@ -21,7 +21,7 @@
     <span id="testspan"></span>
     <input type="text" id="text-input">
     <div id="text-node1">Testing<div style="display:none;">invisible</div><div>text<span>.</span></div></div>
-    <div id="text-node2" />
+    <div id="text-node2"></div>
     <div id="text-node3" style="display:none;">invisible text node</div>
     <script>
       document.cookie ='jsCookieName1=jsCookieValue1';
@@ -31,5 +31,12 @@
 
     <span id="file-input-onchange"></span>
     <input id="upload" type="file" name="files" onChange="change();">
+
+    <select id="testselect">
+      <option selected>select text 1</option>
+      <option>select text 2</option>
+    </select>
+    <input id="checkbox1" type="checkbox" checked><label for="checkbox1">checkbox text 1</label><br>
+    <input id="checkbox2" type="checkbox"><label for="checkbox2">checkbox text 2</label><br>
   </body>
 </html>


### PR DESCRIPTION
The method `WebElement#isSelected` returns true for checkbox and option elements although they are not checked/selected.

Additionally there is a change for `text-node2` in the test page since self closing divs lead to strange nesting of elements (see http://stackoverflow.com/questions/31880501/div-becomes-child-of-previous-div-a-quirk-of-css-javascript).