### PR TITLE
Make Settings.java take loglevel

### DIFF
--- a/CLA-rev2-digital.txt
+++ b/CLA-rev2-digital.txt
@@ -14,3 +14,4 @@ Contribution is being made on behalf of a corporation.
 
 Arseniy Skvortsov https://github.com/askvortsov/ 2016-07-19
 Valery Yatsynovich https://github.com/valfirst 2016-08-15
+Michael Pinnegar https://github.com/jazzepi 2016-09-12

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,9 @@
             <goals>
               <goal>jar</goal>
             </goals>
+            <configuration>
+              <additionalparam>-Xdoclint:none</additionalparam>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/com/machinepublishers/jbrowserdriver/Settings.java
+++ b/src/com/machinepublishers/jbrowserdriver/Settings.java
@@ -986,6 +986,25 @@ public class Settings implements Serializable {
     }
 
     /**
+     * At what log level the logger should log
+     * <p>
+     * Defaults to <code>Level.ALL</code>
+     * <p>
+     * The loggerLevel can be <code>null</code> meaning no logging will be done.
+     *
+     * @param loggerLevel
+     * @return this Builder
+     */
+    public Builder loggerLevel(Level loggerLevel) {
+      if (loggerLevel == null) {
+        this.logger.setLevel(Level.OFF);
+      } else {
+        this.logger.setLevel(loggerLevel);
+      }
+      return this;
+    }
+
+    /**
      * The name of a Java Logger to handle log messages.
      * <p>
      * Logs are also available via the Selenium logging APIs--this logger has no effect on that.
@@ -1070,7 +1089,7 @@ public class Settings implements Serializable {
      * <li>{@link Capabilities} name <code>jbd.javabinary</code> alternately configures this setting.</li>
      * </ul><p>
      *
-     * @param options
+     * @param javaBinary
      * @return this Builder
      */
     public Builder javaBinary(String javaBinary) {
@@ -1088,7 +1107,7 @@ public class Settings implements Serializable {
      * <li>{@link Capabilities} name <code>jbd.javaexportmodules</code> alternately configures this setting.</li>
      * </ul><p>
      *
-     * @param options
+     * @param javaExportModules
      * @return this Builder
      */
     public Builder javaExportModules(boolean javaExportModules) {
@@ -1496,8 +1515,8 @@ public class Settings implements Serializable {
       String portString = properties.get(PropertyName.PORTS.propertyName).toString();
       Collection<Long> ports = new LinkedHashSet<Long>();
       String[] ranges = portString.split(",");
-      for (int i = 0; i < ranges.length; i++) {
-        String[] bounds = ranges[i].split("-");
+      for (String range : ranges) {
+        String[] bounds = range.split("-");
         long low = Long.parseLong(bounds[0]);
         long high = bounds.length > 1 ? Long.parseLong(bounds[1]) : low;
         for (long j = low; j <= high; j++) {


### PR DESCRIPTION
  *Added ability to set log level on the Settings object. Previously it
  was only being set to a default level, and there was no way to set it
  directly.
  *Fixed up maven compilation under Java 8. Would break on bad javadocs
  without linter turned off.
  *Minor refactorings here and there.