### PR TITLE
Remove usage of Selenium RC classes

### DIFF
--- a/src/com/machinepublishers/jbrowserdriver/Util.java
+++ b/src/com/machinepublishers/jbrowserdriver/Util.java
@@ -40,7 +40,6 @@ import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.internal.WrapsElement;
 
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import com.thoughtworks.selenium.SeleniumException;
 
 class Util {
   private static final Pattern charsetPattern = Pattern.compile(
@@ -126,9 +125,8 @@ class Util {
         throwable = throwable.getCause();
         message = throwable.getMessage();
       }
-      if ((throwable instanceof WebDriverException || throwable instanceof SeleniumException)
-          && throwable instanceof RuntimeException) {
-        //Wrap the exception to ensure complete/helpful stack trace info and also preserve the original subtype 
+      if (throwable instanceof WebDriverException && throwable instanceof RuntimeException) {
+        //Wrap the exception to ensure complete/helpful stack trace info and also preserve the original subtype
         try {
           throwable = throwable.getClass().getConstructor(String.class, Throwable.class).newInstance(message, throwable);
         } catch (Throwable t) {


### PR DESCRIPTION
Remove usage of com.thoughtworks.selenium.SeleniumException.

Selenium RC is officially dead. `com.thoughtworks.selenium.SeleniumException` was excluded from Selenium 3 (starting from 3.0.0-beta3). This commit removes this dependency. IMHO, it's better to support new releases 3+ rather than dead RC.

Issues/question references: #213 , #207 , #196 