### PR TITLE
Terminate child process when parent process killed

### DIFF
--- a/CLA-rev2-digital.txt
+++ b/CLA-rev2-digital.txt
@@ -17,3 +17,4 @@ Valery Yatsynovich https://github.com/valfirst 2016-08-15
 Michael Pinnegar https://github.com/jazzepi 2016-09-12
 Thomas Cashman https://github.com/tomcashman 2016-09-26
 Alex Luketa https://github.com/aluketa 2016-10-14
+Trask Stalnaker https://github.com/trask 2017-02-08

--- a/src/com/machinepublishers/jbrowserdriver/HeartbeatRemote.java
+++ b/src/com/machinepublishers/jbrowserdriver/HeartbeatRemote.java
@@ -1,0 +1,26 @@
+/* 
+ * jBrowserDriver (TM)
+ * Copyright (C) 2017 Machine Publishers, LLC and the jBrowserDriver contributors
+ * https://github.com/MachinePublishers/jBrowserDriver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.machinepublishers.jbrowserdriver;
+
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+
+public interface HeartbeatRemote extends Remote {
+
+  void heartbeat() throws RemoteException;
+}

--- a/src/com/machinepublishers/jbrowserdriver/HeartbeatServer.java
+++ b/src/com/machinepublishers/jbrowserdriver/HeartbeatServer.java
@@ -1,0 +1,56 @@
+/* 
+ * jBrowserDriver (TM)
+ * Copyright (C) 2017 Machine Publishers, LLC and the jBrowserDriver contributors
+ * https://github.com/MachinePublishers/jBrowserDriver
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.machinepublishers.jbrowserdriver;
+
+import java.rmi.RemoteException;
+import java.util.concurrent.Executors;
+
+public class HeartbeatServer extends RemoteObject implements HeartbeatRemote {
+
+  private volatile long lastHeartbeat;
+
+  public HeartbeatServer() throws RemoteException {
+    Executors.newSingleThreadExecutor().execute(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          // give 60 seconds for initial heartbeat
+          Thread.sleep(60000);
+        } catch (InterruptedException e) {}
+        
+        while (true) {
+          if (System.currentTimeMillis() - lastHeartbeat > 60000) {
+            // no heartbeat received in the last 60 seconds
+            System.exit(1);
+          }
+          
+          try {
+            // sleep a bit to avoid busy loop
+            Thread.sleep(5000);
+          } catch (InterruptedException e) {}
+        }
+      }
+    });
+  }
+
+  // this is called every ~5 seconds by parent process
+  @Override
+  public void heartbeat() throws RemoteException {
+    lastHeartbeat = System.currentTimeMillis();
+  }
+}

--- a/src/com/machinepublishers/jbrowserdriver/JBrowserDriverServer.java
+++ b/src/com/machinepublishers/jbrowserdriver/JBrowserDriverServer.java
@@ -1,6 +1,6 @@
 /* 
  * jBrowserDriver (TM)
- * Copyright (C) 2014-2016 Machine Publishers, LLC and the jBrowserDriver contributors
+ * Copyright (C) 2014-2017 Machine Publishers, LLC and the jBrowserDriver contributors
  * https://github.com/MachinePublishers/jBrowserDriver
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -115,6 +115,7 @@ class JBrowserDriverServer extends RemoteObject implements JBrowserDriverRemote,
         }
       }
       registry = registryTmp;
+      registry.rebind("HeartbeatRemote", new HeartbeatServer());
       registry.rebind("JBrowserDriverRemote", new JBrowserDriverServer());
 
       RMISocketFactory.setSocketFactory(socketFactory.get());


### PR DESCRIPTION
Hi, I've been noticing that the JBrowserDriverServer child process is left running indefinitely when I kill my application while the child process is mid-execution.

A shutdown hook on the parent JVM is not totally reliable since it's not called if the parent process is forcibly terminated.

So I added a HeartbeatServer to the child process.  The parent process sends the child process a heartbeat "ping" every 5 seconds, and the child process calls System.exit() if it has not heard from the parent process in over a minute.