### PR TITLE
Fix pageLoadTimeout for AjaxListener

### DIFF
--- a/CLA-rev2-digital.txt
+++ b/CLA-rev2-digital.txt
@@ -12,7 +12,6 @@ Contribution is being made on behalf of a corporation.
 
 [Full Name] [GitHub Profile URL] [YYYY-MM-DD] [Corporation Name--if applicable]
 
-Nicholas DiPiazza https://github.com/nddipiazza/ 2017-08-08
 Arseniy Skvortsov https://github.com/askvortsov/ 2016-07-19
 Valery Yatsynovich https://github.com/valfirst 2016-08-15
 Michael Pinnegar https://github.com/jazzepi 2016-09-12
@@ -24,3 +23,4 @@ Bodo Junglas https://github.com/untoldwind 2017-02-23
 Arya Farzan https://github.com/arya6000 2017-03-18
 Vitali Kepin https://github.com/vkepin 2017-05-16
 D. Hollingsworth https://github.com/hollingsworthd 2017-06-25
+Nicholas DiPiazza https://github.com/nddipiazza/ 2017-08-08

--- a/CLA-rev2-digital.txt
+++ b/CLA-rev2-digital.txt
@@ -12,6 +12,7 @@ Contribution is being made on behalf of a corporation.
 
 [Full Name] [GitHub Profile URL] [YYYY-MM-DD] [Corporation Name--if applicable]
 
+Nicholas DiPiazza https://github.com/nddipiazza/ 2017-08-08
 Arseniy Skvortsov https://github.com/askvortsov/ 2016-07-19
 Valery Yatsynovich https://github.com/valfirst 2016-08-15
 Michael Pinnegar https://github.com/jazzepi 2016-09-12

--- a/src/com/machinepublishers/jbrowserdriver/AjaxListener.java
+++ b/src/com/machinepublishers/jbrowserdriver/AjaxListener.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javafx.application.Platform;
 
@@ -32,16 +33,16 @@ class AjaxListener implements Runnable {
   private final AtomicInteger newStatusCode;
   private final StatusCode statusCode;
   private final Map<String, Long> resources;
-  private final long timeoutMS;
+  private final AtomicLong timeoutMS;
 
   AjaxListener(final AtomicBoolean started, final AtomicInteger newStatusCode,
       final StatusCode statusCode,
-      final Map<String, Long> resources, final long timeoutMS) {
+      final Map<String, Long> resources, final AtomicLong timeoutMS) {
     this.started = started;
     this.newStatusCode = newStatusCode;
     this.statusCode = statusCode;
     this.resources = resources;
-    this.timeoutMS = timeoutMS <= 0 ? MAX_WAIT_DEFAULT : timeoutMS;
+    this.timeoutMS = timeoutMS;
   }
 
   /**
@@ -82,7 +83,7 @@ class AjaxListener implements Runnable {
         final long sleepMS = Math.max(settings.ajaxWait() / IDLE_COUNT_TARGET, 0);
         int idleCount = 0;
         int idleCountTarget = sleepMS == 0 ? 1 : IDLE_COUNT_TARGET;
-        while (time - start < timeoutMS) {
+        while (time - start < (timeoutMS.get() <= 0 ? MAX_WAIT_DEFAULT : timeoutMS.get())) {
           try {
             Thread.sleep(sleepMS);
           } catch (InterruptedException e) {

--- a/src/com/machinepublishers/jbrowserdriver/HttpListener.java
+++ b/src/com/machinepublishers/jbrowserdriver/HttpListener.java
@@ -86,7 +86,7 @@ class HttpListener implements LoadListenerClient {
     this.statusMonitor = StatusMonitor.instance();
     this.logs = LogsServer.instance();
     this.ajaxListener = new AjaxListener(
-        this.started, this.newStatusCode, this.statusCode, this.resources, this.timeoutMS.get());
+        this.started, this.newStatusCode, this.statusCode, this.resources, this.timeoutMS);
   }
 
   void init() {


### PR DESCRIPTION
 By using the .get() of the page load AtomicLong it was no longer seeing the newer values specified by the driver.manage().timeouts().pageLoadTimeout(...);
 Switch to using the AtomicLong and dereference it everytime needed.