### PR TITLE
JBrowserDriverServer.get 's finally block needs a timeout

### DIFF
--- a/src/com/machinepublishers/jbrowserdriver/AppThread.java
+++ b/src/com/machinepublishers/jbrowserdriver/AppThread.java
@@ -132,6 +132,10 @@ class AppThread {
     return exec(false, new StatusCode(), 0, action);
   }
 
+  static <T> T exec(final Sync<T> action, long timeout) {
+    return exec(false, new StatusCode(), timeout, action);
+  }
+
   static <T> T exec(final StatusCode statusCode, final Sync<T> action) {
     return exec(false, statusCode, 0, action);
   }

--- a/src/com/machinepublishers/jbrowserdriver/JBrowserDriverServer.java
+++ b/src/com/machinepublishers/jbrowserdriver/JBrowserDriverServer.java
@@ -337,7 +337,7 @@ class JBrowserDriverServer extends RemoteObject implements JBrowserDriverRemote,
                     .append(context.get().timeouts.get().getPageLoadTimeoutMS())
                     .append("ms reached.").toString());
               }
-            });
+            }, context.get().timeouts.get().getPageLoadTimeoutMS());
       }
     }
   }


### PR DESCRIPTION
# tl;dr 

**DO NOT MERGE** this still needs work.

In `com.machinepublishers.jbrowserdriver.JBrowserDriverServer#get` in the finally block where it is going to wait for a status code, the AppThread.exec method needs to use some sort of timeout. Otherwise it will wait upwards of 10000ms in the sample program below, even though the user is expecting a 2000ms timeout.

In this PR, I use the pageLoadTimeoutMS as a timeout parameter call which is better than nothing.

# To verify

```
import com.google.common.base.Stopwatch;
import com.machinepublishers.jbrowserdriver.Settings;
import com.machinepublishers.jbrowserdriver.JBrowserDriver;
import com.sun.net.httpserver.HttpExchange;
import com.sun.net.httpserver.HttpHandler;
import com.sun.net.httpserver.HttpServer;

import java.io.IOException;
import java.io.OutputStream;
import java.net.InetSocketAddress;
import java.util.concurrent.TimeUnit;

class TestDriverOpts {
  static class MyHandler implements HttpHandler {
    @Override
    public void handle(HttpExchange t) throws IOException {
      String response = "<html>\n" +
          "  <head>\n" +
          "    <script>\n" +
          "      while (true) { }\n" +
          "    </script>\n" +
          "  </head>\n" +
          "</html>";
      t.sendResponseHeaders(200, response.length());
      OutputStream os = t.getResponseBody();
      os.write(response.getBytes());
      os.close();
    }
  }

  public static void main(String[] args) throws InterruptedException, IOException {
    HttpServer server = HttpServer.create(new InetSocketAddress(8000), 0);
    server.createContext("/index.html", new MyHandler());
    server.start();
    Settings.Builder builder = Settings.builder()
        .quickRender(true)
        .ajaxResourceTimeout(2000)
        .ajaxWait(10)
        .connectionReqTimeout(2000)
        .connectTimeout(2000);
//        .javaOptions("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
    JBrowserDriver driver = new JBrowserDriver(builder.build());
    driver.manage().timeouts().setScriptTimeout(2000, TimeUnit.MILLISECONDS);
    driver.manage().timeouts().pageLoadTimeout(2000, TimeUnit.MILLISECONDS);

    for (int i = 0; i < 100; i++) {
      Thread.sleep(1000L);
      Stopwatch stopwatch = Stopwatch.createStarted();
      try {
        System.out.println("BEGIN");
        driver.get("http://127.0.0.1:8000/index.html");
        String result = driver.getPageSource();
        System.out.println(result);
        System.out.println("END took " + stopwatch.elapsed(TimeUnit.MILLISECONDS) + " ms");
      } catch (Exception e) {
         System.out.println("ERROR: " + e.getMessage() + " took " + stopwatch.elapsed(TimeUnit.MILLISECONDS));
      }
    }
    Thread.sleep(500000);
    System.exit(0);
  }
}
```

*Expected*: Timeout should not be 10000ms, it should be closer to the page timeout.

NOTE: This still needs work. In this state it is waiting `2*pageTimeout`

If I replace

https://github.com/MachinePublishers/jBrowserDriver/pull/291/files#diff-048530290a10b616323dcd32f8c164e1R340

with 

`            }, 500);`

it will be much closer to the actual timeout. What would be the side effect of doing this? 
