### PR TITLE
hotfix deprecated interface

### DIFF
--- a/src/com/machinepublishers/jbrowserdriver/JBrowserDriver.java
+++ b/src/com/machinepublishers/jbrowserdriver/JBrowserDriver.java
@@ -58,7 +58,6 @@ import org.openqa.selenium.Cookie;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.internal.Killable;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.remote.CommandExecutor;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -84,7 +83,7 @@ import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
  * <p>
  * Licensed under the Apache License version 2.0.
  */
-public class JBrowserDriver extends RemoteWebDriver implements Killable {
+public class JBrowserDriver extends RemoteWebDriver {
 
   //TODO handle jbd.fork=false
 
@@ -1244,7 +1243,7 @@ public class JBrowserDriver extends RemoteWebDriver implements Killable {
   /**
    * {@inheritDoc}
    */
-  @Override
+  @Deprecated
   public void kill() {
     endProcess();
   }

--- a/src/com/machinepublishers/jbrowserdriver/JBrowserDriverServer.java
+++ b/src/com/machinepublishers/jbrowserdriver/JBrowserDriverServer.java
@@ -58,7 +58,6 @@ import org.openqa.selenium.internal.FindsByLinkText;
 import org.openqa.selenium.internal.FindsByName;
 import org.openqa.selenium.internal.FindsByTagName;
 import org.openqa.selenium.internal.FindsByXPath;
-import org.openqa.selenium.internal.Killable;
 
 import com.machinepublishers.jbrowserdriver.AppThread.Sync;
 import com.sun.javafx.webkit.Accessor;
@@ -68,7 +67,7 @@ import com.sun.webkit.network.CookieManager;
 class JBrowserDriverServer extends RemoteObject implements JBrowserDriverRemote,
     WebDriver, JavascriptExecutor, FindsById, FindsByClassName, FindsByLinkText, FindsByName,
     FindsByCssSelector, FindsByTagName, FindsByXPath, HasInputDevices, HasCapabilities,
-    TakesScreenshot, Killable {
+    TakesScreenshot {
   private static final AtomicInteger childPort = new AtomicInteger();
   private static final AtomicReference<SocketFactory> socketFactory = new AtomicReference<SocketFactory>();
   private static Registry registry;
@@ -622,7 +621,7 @@ class JBrowserDriverServer extends RemoteObject implements JBrowserDriverRemote,
   /**
    * {@inheritDoc}
    */
-  @Override
+  @Deprecated
   public void kill() {}
 
   /**


### PR DESCRIPTION
Hello!

While using your lib I figured out that it conflicts with last versions of selenium-java. The point is that the 'Killable' interface was deprecated and then removed from selenium lib since no class implements it anymore.
This is just a hot fix to make the project using both your lib and selenium even compile.
Please consider a replacement for this interface since it's not maintained anymore.