### PR TITLE
Remove selenium Killable interface references

### DIFF
--- a/src/com/machinepublishers/jbrowserdriver/JBrowserDriver.java
+++ b/src/com/machinepublishers/jbrowserdriver/JBrowserDriver.java
@@ -58,7 +58,6 @@ import org.openqa.selenium.Cookie;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.internal.Killable;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.remote.CommandExecutor;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -84,7 +83,7 @@ import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
  * <p>
  * Licensed under the Apache License version 2.0.
  */
-public class JBrowserDriver extends RemoteWebDriver implements Killable {
+public class JBrowserDriver extends RemoteWebDriver {
 
   //TODO handle jbd.fork=false
 
@@ -1239,14 +1238,6 @@ public class JBrowserDriver extends RemoteWebDriver implements Killable {
       Util.handleException(t);
       return null;
     }
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void kill() {
-    endProcess();
   }
 
   /**

--- a/src/com/machinepublishers/jbrowserdriver/JBrowserDriverServer.java
+++ b/src/com/machinepublishers/jbrowserdriver/JBrowserDriverServer.java
@@ -58,7 +58,6 @@ import org.openqa.selenium.internal.FindsByLinkText;
 import org.openqa.selenium.internal.FindsByName;
 import org.openqa.selenium.internal.FindsByTagName;
 import org.openqa.selenium.internal.FindsByXPath;
-import org.openqa.selenium.internal.Killable;
 
 import com.machinepublishers.jbrowserdriver.AppThread.Sync;
 import com.sun.javafx.webkit.Accessor;
@@ -68,7 +67,7 @@ import com.sun.webkit.network.CookieManager;
 class JBrowserDriverServer extends RemoteObject implements JBrowserDriverRemote,
     WebDriver, JavascriptExecutor, FindsById, FindsByClassName, FindsByLinkText, FindsByName,
     FindsByCssSelector, FindsByTagName, FindsByXPath, HasInputDevices, HasCapabilities,
-    TakesScreenshot, Killable {
+    TakesScreenshot {
   private static final AtomicInteger childPort = new AtomicInteger();
   private static final AtomicReference<SocketFactory> socketFactory = new AtomicReference<SocketFactory>();
   private static Registry registry;


### PR DESCRIPTION
Killabe is Selenium internal interface. It was deprecated in Selenium 3.5.0 and [removed in Selenium 3.6.0](https://github.com/SeleniumHQ/selenium/commit/550717bc07a732e8a8a64b0a97e757c6f14a0fd8#diff-0ce3ec5a1f39171c1803df5b33fd19da). This change makes jBrowserDriver compatible with Selenium 3.6.0.