### PR TITLE
Upgrade to Selenium 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <selenium.version>2.53.0</selenium.version> <!-- note: selenium does not follow semantic versioning -->
+    <selenium.version>3.8.1</selenium.version> <!-- note: selenium does not follow semantic versioning -->
   </properties>
   <dependencies>
     <dependency>

--- a/src/com/machinepublishers/jbrowserdriver/Alert.java
+++ b/src/com/machinepublishers/jbrowserdriver/Alert.java
@@ -17,8 +17,6 @@
  */
 package com.machinepublishers.jbrowserdriver;
 
-import org.openqa.selenium.security.Credentials;
-
 class Alert implements org.openqa.selenium.Alert {
 
   private final AlertRemote remote;
@@ -84,21 +82,5 @@ class Alert implements org.openqa.selenium.Alert {
     } catch (Throwable t) {
       Util.handleException(t);
     }
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void authenticateUsing(Credentials credentials) {
-    //TODO handle basic auth
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void setCredentials(Credentials credentials) {
-    // TODO handle basic auth
   }
 }

--- a/src/com/machinepublishers/jbrowserdriver/AlertRemote.java
+++ b/src/com/machinepublishers/jbrowserdriver/AlertRemote.java
@@ -20,18 +20,12 @@ package com.machinepublishers.jbrowserdriver;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
 
-import org.openqa.selenium.security.Credentials;
-
 interface AlertRemote extends Remote {
   void accept() throws RemoteException;
-
-  void authenticateUsing(Credentials arg0) throws RemoteException;
 
   void dismiss() throws RemoteException;
 
   String getText() throws RemoteException;
 
   void sendKeys(String arg0) throws RemoteException;
-
-  void setCredentials(Credentials credentials) throws RemoteException;
 }

--- a/src/com/machinepublishers/jbrowserdriver/AlertServer.java
+++ b/src/com/machinepublishers/jbrowserdriver/AlertServer.java
@@ -22,8 +22,6 @@ import java.util.LinkedList;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.openqa.selenium.security.Credentials;
-
 import javafx.event.EventHandler;
 import javafx.scene.web.PromptData;
 import javafx.scene.web.WebEvent;
@@ -102,22 +100,6 @@ class AlertServer extends RemoteObject implements AlertRemote,
     synchronized (lock) {
       inputs.add(text);
     }
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void setCredentials(Credentials credentials) {
-    // TODO Auto-generated method stub
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public void authenticateUsing(Credentials arg0) {
-    //TODO handle basic auth
   }
 
   private final class AlertHandler implements EventHandler<WebEvent<String>> {

--- a/src/com/machinepublishers/jbrowserdriver/Element.java
+++ b/src/com/machinepublishers/jbrowserdriver/Element.java
@@ -29,6 +29,7 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.internal.Locatable;
 import org.openqa.selenium.internal.FindsByClassName;
 import org.openqa.selenium.internal.FindsByCssSelector;
 import org.openqa.selenium.internal.FindsById;
@@ -36,7 +37,6 @@ import org.openqa.selenium.internal.FindsByLinkText;
 import org.openqa.selenium.internal.FindsByName;
 import org.openqa.selenium.internal.FindsByTagName;
 import org.openqa.selenium.internal.FindsByXPath;
-import org.openqa.selenium.internal.Locatable;
 import org.openqa.selenium.internal.WrapsDriver;
 
 class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClassName,

--- a/src/com/machinepublishers/jbrowserdriver/diagnostics/Test.java
+++ b/src/com/machinepublishers/jbrowserdriver/diagnostics/Test.java
@@ -46,7 +46,7 @@ import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.internal.Locatable;
+import org.openqa.selenium.interactions.internal.Locatable;
 import org.openqa.selenium.logging.LogEntry;
 
 import com.machinepublishers.jbrowserdriver.JBrowserDriver;


### PR DESCRIPTION
Beta functionality allowing to authenticate via alert was removed in Selenium 3.8.0 (https://github.com/SeleniumHQ/selenium/commit/bdf883bf519e3ab60ac35f9ecaeb37bb5b11c046). This change breaks compatibility of jBrowserDriver with previous versions of Selenium and requires version update