### PR TITLE
Upgrade to zt-process-killer 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
     </dependency>
     <dependency>
       <groupId>org.zeroturnaround</groupId>
-      <artifactId>zt-process</artifactId>
-      <version>1.3</version>
+      <artifactId>zt-process-killer</artifactId>
+      <version>1.8</version>
     </dependency>
     <dependency>
       <groupId>io.github.lukehutch</groupId>


### PR DESCRIPTION
"zt-process" was renamed to "zt-process-killer" starting from version 1.4: https://github.com/zeroturnaround/zt-process-killer/blob/master/Changelog.txt