### PR TITLE
Upgrade to Selenium 3.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <selenium.version>3.8.1</selenium.version> <!-- note: selenium does not follow semantic versioning -->
+    <selenium.version>3.14.0</selenium.version> <!-- note: selenium does not follow semantic versioning -->
   </properties>
   <dependencies>
     <dependency>

--- a/src/com/machinepublishers/jbrowserdriver/Element.java
+++ b/src/com/machinepublishers/jbrowserdriver/Element.java
@@ -29,7 +29,7 @@ import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.internal.Locatable;
+import org.openqa.selenium.interactions.Locatable;
 import org.openqa.selenium.internal.FindsByClassName;
 import org.openqa.selenium.internal.FindsByCssSelector;
 import org.openqa.selenium.internal.FindsById;
@@ -37,10 +37,12 @@ import org.openqa.selenium.internal.FindsByLinkText;
 import org.openqa.selenium.internal.FindsByName;
 import org.openqa.selenium.internal.FindsByTagName;
 import org.openqa.selenium.internal.FindsByXPath;
-import org.openqa.selenium.internal.WrapsDriver;
+import org.openqa.selenium.WrapsDriver;
 
 class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClassName,
     FindsByLinkText, FindsByName, FindsByCssSelector, FindsByTagName, FindsByXPath, Locatable,
+    org.openqa.selenium.interactions.internal.Locatable, // Selenium 3.14 API (org.openqa.selenium.interactions.Actions) uses deprecated interface internally,
+                                                         // so we should implement it as well to avoid type casting issues.
     WrapsDriver {
   private final ElementRemote remote;
   private final JBrowserDriver driver;

--- a/src/com/machinepublishers/jbrowserdriver/Util.java
+++ b/src/com/machinepublishers/jbrowserdriver/Util.java
@@ -37,7 +37,7 @@ import javax.net.ssl.SSLProtocolException;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.http.ConnectionClosedException;
 import org.openqa.selenium.WebDriverException;
-import org.openqa.selenium.internal.WrapsElement;
+import org.openqa.selenium.WrapsElement;
 
 import com.google.common.util.concurrent.UncheckedExecutionException;
 

--- a/src/com/machinepublishers/jbrowserdriver/diagnostics/Test.java
+++ b/src/com/machinepublishers/jbrowserdriver/diagnostics/Test.java
@@ -46,7 +46,7 @@ import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.interactions.internal.Locatable;
+import org.openqa.selenium.interactions.Locatable;
 import org.openqa.selenium.logging.LogEntry;
 
 import com.machinepublishers.jbrowserdriver.JBrowserDriver;


### PR DESCRIPTION
Selenium deprecated a set of interfaces and switched internally to new types. It broke compatibility of jBrowserDriver with Selenium 3.14.+ and requires version update.