### PR TITLE
Add missing cookie options when restoring a cookie

### DIFF
--- a/CLA-rev2-digital.txt
+++ b/CLA-rev2-digital.txt
@@ -28,3 +28,4 @@ Alena Liashenka https://github.com/eichhornchen27 2017-12-08
 Uladzislau Arlouski https://github.com/uarlouski 2017-12-11
 contributions by (Vincent Smith https://github.com/vosmith 2018-06-08)
 included by (Adam Howard https://github.com/medavox 2018-07-06)
+Luis Fernandes https://github.com/zipleen 2019-07-30


### PR DESCRIPTION
I've added some missing cookie options: domain, path, expires, secure and httponly are required by some websites, otherwise the cookie is considered invalid.

The patch is pretty innocuous, but my main 2 concerns on this patch are:
- in order to get "httponly" we need to cast to ClientCookie (Cookie does not expose this)
- the cookie format was not checked to see if it's always like this, and timezone is hardcoded to GMT (I didn't check the cookie specs to see that this is always true, I just followed what Chrome was receiving / sending)

Regardless, this should improve reliability when saving / restoring cookies from jBrowser.

