### PR TITLE
1.0.2 release - To work with current release version of Selenium 3 (v3.141.59)

### DIFF
--- a/CLA-rev2-digital.txt
+++ b/CLA-rev2-digital.txt
@@ -29,3 +29,4 @@ Uladzislau Arlouski https://github.com/uarlouski 2017-12-11
 contributions by (Vincent Smith https://github.com/vosmith 2018-06-08)
 included by (Adam Howard https://github.com/medavox 2018-07-06)
 Luis Fernandes https://github.com/zipleen 2019-07-30
+Jeff Vincent https://github.com/PredatorVI 2019-09-24

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <selenium.version>4.0.0-alpha-1</selenium.version> <!-- note: selenium does not follow semantic versioning -->
+    <selenium.version>3.141.0</selenium.version> <!-- note: selenium does not follow semantic versioning -->
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>jbrowserdriver</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>A programmable, embeddable web browser driver compatible with the Selenium WebDriver spec -- headless, WebKit-based, pure Java</description>
-  <version>1.1.1-SNAPSHOT</version>
+  <version>1.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
   <url>https://github.com/machinepublishers/jbrowserdriver</url>
   <scm>
@@ -34,23 +34,23 @@
   </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <selenium.version>3.141.0</selenium.version> <!-- note: selenium does not follow semantic versioning -->
+    <selenium.version>3.141.59</selenium.version> <!-- note: selenium does not follow semantic versioning -->
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient-cache</artifactId>
-      <version>4.5.4</version>
+      <version>4.5.10</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.25</version>
+      <version>1.7.28</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.25</version>
+      <version>1.7.28</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -301,17 +301,23 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>23.5-jre</version>
+      <version>28.1-jre</version>
     </dependency>
     <dependency>
       <groupId>org.zeroturnaround</groupId>
       <artifactId>zt-process-killer</artifactId>
-      <version>1.8</version>
+      <version>1.10</version>
     </dependency>
     <dependency>
       <groupId>io.github.classgraph</groupId>
       <artifactId>classgraph</artifactId>
-      <version>4.4.12</version>
+      <version>4.8.47</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-lang</groupId>
+      <artifactId>commons-lang</artifactId>
+      <version>2.6</version>
+      <type>jar</type>
     </dependency>
   </dependencies>
   <distributionManagement>
@@ -345,7 +351,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.8.1</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -354,7 +360,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.2.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -367,7 +373,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4.3</version>
+        <version>3.2.1</version>
         <configuration>
           <shadedArtifactAttached>true</shadedArtifactAttached>
           <shadedClassifierName>uberjar</shadedClassifierName>
@@ -384,7 +390,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.1</version>
         <configuration>
           <nodeprecated>true</nodeprecated>
           <includeDependencySources>false</includeDependencySources> <!-- should be set to true but fails with permissions errors so disabling for now -->
@@ -421,7 +427,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -435,7 +441,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.3</version>
+            <version>1.6.8</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>

--- a/src/com/machinepublishers/jbrowserdriver/Element.java
+++ b/src/com/machinepublishers/jbrowserdriver/Element.java
@@ -41,6 +41,8 @@ import org.openqa.selenium.WrapsDriver;
 
 class Element implements WebElement, JavascriptExecutor, FindsById, FindsByClassName,
     FindsByLinkText, FindsByName, FindsByCssSelector, FindsByTagName, FindsByXPath, Locatable,
+    org.openqa.selenium.interactions.internal.Locatable, // Selenium 3.14 API (org.openqa.selenium.interactions.Actions) uses deprecated interface internally,
+                                                         // so we should implement it as well to avoid type casting issues.
     WrapsDriver {
   private final ElementRemote remote;
   private final JBrowserDriver driver;

--- a/src/com/machinepublishers/jbrowserdriver/TargetLocator.java
+++ b/src/com/machinepublishers/jbrowserdriver/TargetLocator.java
@@ -19,9 +19,8 @@ package com.machinepublishers.jbrowserdriver;
 
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.WindowType;
 
-class TargetLocator implements WebDriver.TargetLocator {
+class TargetLocator implements org.openqa.selenium.WebDriver.TargetLocator {
   private final TargetLocatorRemote remote;
   private final JBrowserDriver driver;
   private final SocketLock lock;
@@ -143,19 +142,6 @@ class TargetLocator implements WebDriver.TargetLocator {
     try {
       synchronized (lock.validated()) {
         remote.window(windowHandle);
-      }
-      return driver;
-    } catch (Throwable t) {
-      Util.handleException(t);
-      return null;
-    }
-  }
-
-  @Override
-  public WebDriver newWindow(WindowType windowType) {
-    try {
-      synchronized (lock.validated()) {
-        remote.newWindow(windowType);
       }
       return driver;
     } catch (Throwable t) {

--- a/src/com/machinepublishers/jbrowserdriver/TargetLocatorRemote.java
+++ b/src/com/machinepublishers/jbrowserdriver/TargetLocatorRemote.java
@@ -20,9 +20,6 @@ package com.machinepublishers.jbrowserdriver;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
 
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WindowType;
-
 interface TargetLocatorRemote extends Remote {
   ElementRemote activeElement() throws RemoteException;
 
@@ -39,6 +36,4 @@ interface TargetLocatorRemote extends Remote {
   JBrowserDriverRemote parentFrame() throws RemoteException;
 
   JBrowserDriverRemote window(String windowHandle) throws RemoteException;
-
-  JBrowserDriverRemote newWindow(WindowType windowType) throws RemoteException;
 }

--- a/src/com/machinepublishers/jbrowserdriver/TargetLocatorServer.java
+++ b/src/com/machinepublishers/jbrowserdriver/TargetLocatorServer.java
@@ -21,11 +21,10 @@ import java.rmi.RemoteException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.WindowType;
 
-class TargetLocatorServer extends RemoteObject implements TargetLocatorRemote, WebDriver.TargetLocator {
+class TargetLocatorServer extends RemoteObject implements TargetLocatorRemote,
+    org.openqa.selenium.WebDriver.TargetLocator {
 
   private final JBrowserDriverServer driver;
   private final Context context;
@@ -125,12 +124,6 @@ class TargetLocatorServer extends RemoteObject implements TargetLocatorRemote, W
   @Override
   public JBrowserDriverServer window(String windowHandle) {
     context.setCurrent(windowHandle);
-    return driver;
-  }
-
-  @Override
-  public JBrowserDriverServer newWindow(WindowType windowType) {
-    context.spawn(driver);
     return driver;
   }
 }

--- a/src/com/machinepublishers/jbrowserdriver/diagnostics/Test.java
+++ b/src/com/machinepublishers/jbrowserdriver/diagnostics/Test.java
@@ -45,7 +45,6 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.WindowType;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.interactions.Locatable;
 import org.openqa.selenium.logging.LogEntry;
@@ -144,9 +143,9 @@ public class Test {
        * Javascript logs
        */
       int messages = 0;
-      for (LogEntry entry : driver.manage().logs().get("javascript")) {
-          ++messages;
-          test(!StringUtils.isEmpty(entry.getMessage()));
+      for (LogEntry entry : driver.manage().logs().get("javascript").filter(Level.ALL)) {
+        ++messages;
+        test(!StringUtils.isEmpty(entry.getMessage()));
       }
       test(messages == 3);
 
@@ -511,19 +510,6 @@ public class Test {
       test(driver.manage().window().getPosition().getY() == 0);
       test(driver.manage().window().getSize().getWidth() == 1024);
       test(driver.manage().window().getSize().getHeight() == 768);
-
-      /*
-       * Windows
-       */
-      String windowHandle = driver.getWindowHandle();
-      driver.switchTo().newWindow(WindowType.TAB);
-      test(driver.getWindowHandles().size() == 2);
-      driver.switchTo().window(new ArrayList<>(driver.getWindowHandles()).get(1));
-      test(!windowHandle.equals(driver.getWindowHandle()));
-      driver.close();
-      test(driver.getWindowHandles().size() == 1);
-      driver.switchTo().window(windowHandle);
-      test(windowHandle.equals(driver.getWindowHandle()));
 
       /*
        * Element visibility


### PR DESCRIPTION
Running against Oracle JDK 8u212 using JBrowserDriver v1.0.1 failed due to additional methods added to the com.sun.glass.ui.Timer abstract class.  This was fixed already in #350.  However, commit #347 changed the selenium version to v4.0.0-alpha-1 and added references to a WindowType class that is not available in Selenium 3.141.x.

This pull request fixes #353 to work with Selenium 3.141.x by merging all changes compatible with Selenium 3.141.x. I prefer not to use an alpha version of Selenium in my production environment, while needing to be able to use security and other updates that are part of the Oracle Java 8u212 and later, specifically Java 8u221